### PR TITLE
feat: options page

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "tailwindcss": "^2.0.2"
   },
   "dependencies": {
-    "preact": "^10.5.12"
+    "preact": "^10.5.12",
+    "use-chrome-storage": "^1.0.0"
   },
   "alias": {
     "react": "preact/compat",

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -1,0 +1,66 @@
+import { render } from "preact";
+import { useState, useEffect } from 'preact/hooks';
+// import "tailwindcss/tailwind.css"; // TODO - Get this to work instead of using style.css
+import "../style.css";
+
+
+// TODO 'useChromeStorage' custom hook for acessing and setting storage
+
+const Options = () => {
+  const [toggleActive, setToggleActive] = useState();
+  useEffect(() => {
+    chrome.storage.local.get("darkMode", (result) => {
+      setToggleActive(result.darkMode || false);
+    });
+  }, [])
+
+  const setDarkMode = () => {
+    chrome.storage.local.set({darkMode: !toggleActive}, () => {
+      setToggleActive(!toggleActive);
+    })
+  }
+  return (
+    <div class="bg-gray-50 antialiased text-gray-900">
+      <header class="p-4 flex flex-row items-stretch justify-between bg-gray-100 shadow">
+        <div class="h-24 w-24 rounded-full bg-primary flex items-center justify-center text-white font-bold text-4xl">D</div>
+        <h1 class="flex-grow-6 inline-block text-2xl font-medium self-center pl-2">Dash Settings</h1>
+      </header>
+      <div class="bg-blue-100 rounded-lg p-4 m-4">
+        <h2 class="font-medium underline uppercase">
+          This extension is still in development
+        </h2>
+        <span>Have an idea around how I can improve this extension? I welcome any suggestions and bug reports!</span>
+        <div class="w-40">
+          <a href="mailto:matt@mcconway.nz?subject=Dash - Suggestion/Bug Report">
+            <div class="rounded-full bg-primary py-2 px-4 text-white font-medium mt-2 flex flex-row items-center justify-center">
+              <div class="w-4 h-4 inline-block mr-2">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                  <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+                  <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+                </svg>
+              </div>   
+              <span>Send me an email</span>
+            </div>
+          </a>
+        </div>
+      </div>
+      <div class="px-4">
+        <h2 class="text-xl font-medium">Appearance</h2>
+        <ul class="bg-white shadow py-4 px-10 mt-2 rounded-lg">
+          <li>
+            <div class="flex flex-row items-center justify-between font-medium p-4" onClick={setDarkMode}>
+              Enable Dark Mode
+              <div class={`w-12 h-6 flex items-center bg-gray-300 rounded-full p-1 duration-300 ease-in-out ${toggleActive && 'bg-primary'}`}>
+                <div class={`bg-white w-4 h-4 rounded-full shadow-md transform duration-300 ease-in-out ${toggleActive && 'translate-x-6'}`}></div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  render(<Options />, document.body);
+});

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -18,12 +18,12 @@ const Options = () => {
   };
 
   return isPersistent && !error && (
-    <div class="bg-gray-50 w-full h-full antialiased text-gray-900">
-      <header class="p-4 flex flex-row items-stretch justify-between bg-gray-100 shadow">
+    <div class="bg-gray-50 min-h-screen antialiased text-gray-900 dark:bg-gray-600 transition-all duration-300 ease-in-out">
+      <header class="p-4 flex flex-row items-stretch justify-between bg-gray-100 dark:bg-gray-700 shadow">
         <div class="h-24 w-24 rounded-full bg-primary flex items-center justify-center text-white font-bold text-4xl">D</div>
-        <h1 class="flex-grow-6 inline-block text-2xl font-medium self-center pl-2">Dash Settings</h1>
+        <h1 class="flex-grow-6 inline-block text-2xl font-medium self-center pl-2 dark:text-gray-300">Dash Settings</h1>
       </header>
-      <div class="bg-blue-100 rounded-lg p-4 m-4">
+      <div class="bg-blue-300 rounded-lg p-4 m-4 dark:bg-blue-900 dark:text-gray-300 shadow">
         <h2 class="font-medium underline uppercase text-lg">
           This extension is still in development
         </h2>
@@ -42,9 +42,9 @@ const Options = () => {
           </a>
         </div>
       </div>
-      <div class="px-4">
+      <div class="px-4 dark:text-gray-300">
         <h2 class="text-xl font-medium">Appearance</h2>
-        <ul class="bg-white shadow py-4 px-10 mt-2 rounded-lg">
+        <ul class="bg-white shadow py-4 px-10 mt-2 rounded-lg dark:bg-gray-700">
           <li>
             <div class="flex flex-row items-center justify-between font-medium p-4 text-base" onClick={() => handleChange("darkMode", !settings.darkMode)}>
               Enable Dark Mode

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -1,35 +1,33 @@
 import { render } from "preact";
-import { useState, useEffect } from 'preact/hooks';
+import { useSettingsStore } from "./useSettingsStore";
+import { useDarkMode } from "./useDarkMode";
 // import "tailwindcss/tailwind.css"; // TODO - Get this to work instead of using style.css
 import "../style.css";
 
-
-// TODO 'useChromeStorage' custom hook for acessing and setting storage
-
 const Options = () => {
-  const [toggleActive, setToggleActive] = useState();
-  useEffect(() => {
-    chrome.storage.local.get("darkMode", (result) => {
-      setToggleActive(result.darkMode || false);
-    });
-  }, [])
+  const [settings, setSettings, isPersistent, error] = useSettingsStore();
+  useDarkMode();
 
-  const setDarkMode = () => {
-    chrome.storage.local.set({darkMode: !toggleActive}, () => {
-      setToggleActive(!toggleActive);
-    })
-  }
-  return (
-    <div class="bg-gray-50 antialiased text-gray-900">
+  const handleChange = (key, value) => {
+    setSettings(prevState => {
+      return {
+        ...prevState,
+        [key]: value
+      };
+    });
+  };
+
+  return isPersistent && !error && (
+    <div class="bg-gray-50 w-full h-full antialiased text-gray-900">
       <header class="p-4 flex flex-row items-stretch justify-between bg-gray-100 shadow">
         <div class="h-24 w-24 rounded-full bg-primary flex items-center justify-center text-white font-bold text-4xl">D</div>
         <h1 class="flex-grow-6 inline-block text-2xl font-medium self-center pl-2">Dash Settings</h1>
       </header>
       <div class="bg-blue-100 rounded-lg p-4 m-4">
-        <h2 class="font-medium underline uppercase">
+        <h2 class="font-medium underline uppercase text-lg">
           This extension is still in development
         </h2>
-        <span>Have an idea around how I can improve this extension? I welcome any suggestions and bug reports!</span>
+        <span class="text-base">Have an idea around how I can improve this extension? I welcome any suggestions and bug reports!</span>
         <div class="w-40">
           <a href="mailto:matt@mcconway.nz?subject=Dash - Suggestion/Bug Report">
             <div class="rounded-full bg-primary py-2 px-4 text-white font-medium mt-2 flex flex-row items-center justify-center">
@@ -48,10 +46,10 @@ const Options = () => {
         <h2 class="text-xl font-medium">Appearance</h2>
         <ul class="bg-white shadow py-4 px-10 mt-2 rounded-lg">
           <li>
-            <div class="flex flex-row items-center justify-between font-medium p-4" onClick={setDarkMode}>
+            <div class="flex flex-row items-center justify-between font-medium p-4 text-base" onClick={() => handleChange("darkMode", !settings.darkMode)}>
               Enable Dark Mode
-              <div class={`w-12 h-6 flex items-center bg-gray-300 rounded-full p-1 duration-300 ease-in-out ${toggleActive && 'bg-primary'}`}>
-                <div class={`bg-white w-4 h-4 rounded-full shadow-md transform duration-300 ease-in-out ${toggleActive && 'translate-x-6'}`}></div>
+              <div class={`w-12 h-6 flex items-center bg-gray-300 rounded-full p-1 duration-300 ease-in-out ${settings.darkMode && 'bg-primary'}`}>
+                <div class={`bg-white w-4 h-4 rounded-full shadow-md transform duration-300 ease-in-out ${settings.darkMode && 'translate-x-6'}`}></div>
               </div>
             </div>
           </li>

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1,5 +1,6 @@
 import { render } from "preact";
-import { useEffect, useReducer, useState } from 'preact/hooks';
+import { useEffect, useReducer } from 'preact/hooks';
+import { useDarkMode } from './useDarkMode';
 // import "tailwindcss/tailwind.css"; // TODO - Get this to work instead of using style.css
 import "../style.css";
 import { Header } from "./Header";
@@ -64,6 +65,7 @@ const useFetch = (url, requestOptions, initialData) => {
 }
 
 const Popup = () => {
+  useDarkMode();
   
   const [{data, loading, error}] = useFetch(`${process.env.API_URL}/Listings/oneDollar.json?photo_size=Gallery`, {
     method: "get",

--- a/src/js/useDarkMode.js
+++ b/src/js/useDarkMode.js
@@ -1,0 +1,9 @@
+import { useEffect } from 'preact/hooks';
+import { useSettingsStore } from './useSettingsStore';
+
+export const useDarkMode = () => {
+  const [settings] = useSettingsStore();
+  useEffect(() => {
+    settings.darkMode ? document.documentElement.classList.add("dark") : document.documentElement.classList.remove("dark");
+  }, [settings]);
+}

--- a/src/js/useSettingsStore.js
+++ b/src/js/useSettingsStore.js
@@ -1,0 +1,8 @@
+import {createChromeStorageStateHookLocal} from "use-chrome-storage";
+
+const SETTINGS_KEY = "settings";
+const INITIAL_VALUE = {
+  darkMode: false
+};
+
+export const useSettingsStore = createChromeStorageStateHookLocal(SETTINGS_KEY, INITIAL_VALUE);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,8 @@
   "manifest_version": 2,
   "permissions": [
     "tabs",
-    "contextMenus"
+    "contextMenus",
+    "storage"
   ],
   "background": {
     "scripts": [

--- a/src/options.html
+++ b/src/options.html
@@ -4,6 +4,6 @@
     <title>Options</title>
   </head>
   <body>
-    <script src="./js/app.js"></script>
+    <script src="./js/options.js"></script>
   </body>
 </html>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ module.exports = {
     './src/**/*.html',
     './src/**/*.{js,jsx}',
   ],
-  darkMode: false, // or 'media' or 'class'
+  darkMode: 'class', // or 'media' or 'class'
   theme: {
     extend: {
       flexGrow: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7317,6 +7317,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-chrome-storage@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/use-chrome-storage/-/use-chrome-storage-1.0.0.tgz#9651ef9954479a9652086a1ac1429aae00be0671"
+  integrity sha512-g5CbeBsQ9PblJI4KZwDTS/lKVNXZCGZFNazLioGZhmTZ1BQs8LpawPI8QJpECKnUFTPVnFqUQBkFrJ8cAACEVw==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
Adds the option page with settings persisted in local chrome storage, and barebones dark mode for the options page (couldn't style popup as TradeMe Sandbox was returning 500. Need to add mocks!)